### PR TITLE
Make bottle name available as constant in container.

### DIFF
--- a/src/Bottle/pop.js
+++ b/src/Bottle/pop.js
@@ -20,6 +20,7 @@ var pop = function pop(name) {
         instance = bottles[name];
         if (!instance) {
             bottles[name] = instance = new Bottle();
+            instance.constant('BOTTLE_NAME', name);
         }
         return instance;
     }

--- a/test/spec/pop.spec.js
+++ b/test/spec/pop.spec.js
@@ -1,5 +1,5 @@
 /* globals Bottle */
-;(function() {
+;(function(undefined) {
     'use strict';
 
     /**
@@ -16,6 +16,14 @@
             expect(Bottle.pop('Soda')).toBe(Bottle.pop('Soda'));
             expect(Bottle.pop('Pop')).toBe(Bottle.pop('Pop'));
             expect(Bottle.pop('Soda')).not.toBe(Bottle.pop('Pop'));
+        });
+        it('will not have name if not passed a name parameter', function() {
+            var bottle = Bottle.pop();
+            expect(bottle.container.BOTTLE_NAME).toBe(undefined);
+        });
+        it('will make the instance name available when a name is passed', function() {
+            var bottle = Bottle.pop('Soda');
+            expect(bottle.container.BOTTLE_NAME).toBe('Soda');
         });
     });
 }());


### PR DESCRIPTION
This allows for providers/factories the ability to retrieve the name of the bottle from the container by way of the constant: `BOTTLE_NAME`.

IE:

```javascript
var bottle = require('bottlejs').pop('Soda');

console.log(bottle.container.BOTTLE_NAME)
// outputs: soda
```

A more realistic (an immediate example):

```javascript
// ./logger.js
var LogFactory = function(container) {
    var log = function() {};

    log.prototype.debug = function(msg) {
        console.log('[%s] %s', container.BOTTLE_NAME, msg);
    }

    return new log();
}
module.exports = LogFactory;
module.$name = 'logger';
module.$type = 'factory';
```

Later on:

```
var bottle = Bottle.pop('Soda');
bottle.register(require('./logger'));

bottle.container.logger.debug('jerk');
// Output:
// [Soda] jerk
```