### PR TITLE
Allow providers to be overwritten prior to instantiation

### DIFF
--- a/src/Bottle/provider.js
+++ b/src/Bottle/provider.js
@@ -31,16 +31,18 @@ var reducer = function reducer(instance, func) {
  * @return Bottle
  */
 var provider = function provider(fullname, Provider) {
-    var parts, providers, name, id, factory;
-
+    var parts, providers, providerName, name, id, factory;
     id = this.id;
     providers = get(providerMap, id);
-    if (providers[fullname]) {
-        return console.error(fullname + ' provider already registered.');
+    parts = fullname.split('.');
+    if (providers[fullname] && parts.length === 1) {
+        providerName = fullname + 'Provider';
+        if (this.container[providerName] === undefined) {
+            return console.error(fullname + ' provider already instantiated.');
+        }
     }
     providers[fullname] = true;
 
-    parts = fullname.split('.');
     name = parts.shift();
     factory = parts.length ? createSubProvider : createProvider;
 

--- a/test/spec/factory.spec.js
+++ b/test/spec/factory.spec.js
@@ -6,15 +6,29 @@
      * Bottle Factory test suite
      */
     describe('Bottle#factory', function() {
-        it('will log an error if the same key is used twice', function() {
-            var b = new Bottle();
-
-            spyOn(console, 'error');
-            b.factory('same', function(){ });
-            expect(console.error).not.toHaveBeenCalled();
-
-            b.factory('same', function(){ });
-            expect(console.error).toHaveBeenCalled();
+        describe('when the same key is used twice', function() {
+            beforeEach(function() {
+                this.b = new Bottle();
+                spyOn(console, 'error');
+                this.b.factory('same.name', function() {
+                    return function() { };
+                });
+            });
+            describe('when the service has not yet been instantiated', function() {
+                it('doesn\'t log an error', function() {
+                    this.b.factory('same.name', function() { });
+                    expect(console.error).not.toHaveBeenCalled();
+                });
+            });
+            describe('when the service has already been instantiated', function() {
+                beforeEach(function() {
+                    this.b.container.same.name();
+                });
+                it('logs an error', function(){
+                    this.b.factory('same.name', function(){ });
+                    expect(console.error).toHaveBeenCalled();
+                });
+            });
         });
         it('creates a provider instance on the container', function() {
             var b = new Bottle();

--- a/test/spec/provider.spec.js
+++ b/test/spec/provider.spec.js
@@ -6,15 +6,31 @@
      * Bottle Provider test suite
      */
     describe('Bottle#provider', function() {
-        it('will log an error if the same key is used twice', function() {
-            var b = new Bottle();
-
-            spyOn(console, 'error');
-            b.provider('same', function(){ });
-            expect(console.error).not.toHaveBeenCalled();
-
-            b.provider('same', function(){ });
-            expect(console.error).toHaveBeenCalled();
+        describe('when the same key is used twice', function() {
+            beforeEach(function() {
+                this.b = new Bottle();
+                spyOn(console, 'error');
+                this.b.provider('same.name', function() {
+                    this.$get = function() {
+                        return function() { };
+                    };
+                });
+            });
+            describe('when the service has not yet been instantiated', function() {
+                it('doesn\'t log an error', function() {
+                    this.b.provider('same.name', function() { });
+                    expect(console.error).not.toHaveBeenCalled();
+                });
+            });
+            describe('when the service has already been instantiated', function() {
+                beforeEach(function() {
+                    this.b.container.same.name();
+                });
+                it('logs an error', function(){
+                    this.b.provider('same.name', function(){ });
+                    expect(console.error).toHaveBeenCalled();
+                });
+            });
         });
         it('creates a provider instance on the container', function() {
             var b = new Bottle();

--- a/test/spec/service.spec.js
+++ b/test/spec/service.spec.js
@@ -6,15 +6,29 @@
      * Bottle Factory test suite
      */
     describe('Bottle#service', function() {
-        it('will log an error if the same key is used twice', function() {
-            var b = new Bottle();
-
-            spyOn(console, 'error');
-            b.service('same', function(){ });
-            expect(console.error).not.toHaveBeenCalled();
-
-            b.service('same', function(){ });
-            expect(console.error).toHaveBeenCalled();
+        describe('when the same key is used twice', function() {
+            beforeEach(function() {
+                this.b = new Bottle();
+                spyOn(console, 'error');
+                this.b.service('same.name', function() {
+                    return function() { };
+                });
+            });
+            describe('when the service has not yet been instantiated', function() {
+                it('doesn\'t log an error', function() {
+                    this.b.service('same.name', function() { });
+                    expect(console.error).not.toHaveBeenCalled();
+                });
+            });
+            describe('when the service has already been instantiated', function() {
+                beforeEach(function() {
+                    this.b.container.same.name();
+                });
+                it('logs an error', function(){
+                    this.b.service('same.name', function(){ });
+                    expect(console.error).toHaveBeenCalled();
+                });
+            });
         });
         it('creates a provider and service instance on the container', function() {
             var b = new Bottle();


### PR DESCRIPTION
See #36 

It seems to make sense that we can allow dependencies to be overwritten prior to the services actually being instantiated, but I've retained an error when it's attempted *after* the service has already been called (and the property resolved).