### PR TITLE
Don't provide a service when the getter throws an error

### DIFF
--- a/src/Bottle/provider.js
+++ b/src/Bottle/provider.js
@@ -79,12 +79,12 @@ var createProvider = function createProvider(name, Provider) {
             var provider = container[providerName];
             var instance;
             if (provider) {
-                delete container[providerName];
-                delete container[name];
-
                 // filter through decorators
                 instance = getAllWithMapped(decorators, id, name)
                     .reduce(reducer, provider.$get(container));
+
+                delete container[providerName];
+                delete container[name];
             }
             return instance === undefined ? instance : applyMiddleware(id, name, instance, container);
         }

--- a/test/spec/provider.spec.js
+++ b/test/spec/provider.spec.js
@@ -58,6 +58,41 @@
             expect(b.container.Thing instanceof Thing).toBe(true);
             expect(provider.$get).toHaveBeenCalledWith(b.container);
         });
+        describe('when $get throws an error', function() {
+            beforeEach(function() {
+                this.b = new Bottle();
+                this.e = new Error();
+                this.$getSpy = jasmine.createSpy().and.throwError(this.e);
+                var $getSpy = this.$getSpy;
+                this.b.provider('thrower', function() {
+                    this.$get = $getSpy;
+                });
+            });
+            describe('getting the service from the container', function() {
+                it('throws the error', function() {
+                    var context = this;
+                    expect(function() { return context.b.container.thrower; }).toThrow(this.e);
+                });
+                it('continues to throw the error for subsequent requests', function() {
+                    var context = this;
+                    expect(function() { return context.b.container.thrower; }).toThrow(this.e);
+                    expect(function() { return context.b.container.thrower; }).toThrow(this.e);
+                });
+                describe('when $get stops throwing an error', function() {
+                    beforeEach(function() {
+                        this.value = 'OK';
+                        this.$getSpy.and.returnValue(this.value);
+                    });
+                    it('no longer throws the error', function() {
+                        var context = this;
+                        expect(function() { return context.b.container.thrower; }).not.toThrow();
+                    });
+                    it('returns the service', function() {
+                        expect(this.b.container.thrower).toBe(this.value);
+                    });
+                });
+            });
+        });
 
         it('lazily creates the service it provides', function() {
             var i = 0;


### PR DESCRIPTION
In the case where I have an external service which may not be ready (say it has to be loaded asynchronously), I want to throw an error:
```javascript
bottle.factory("asyncService", function(container) {
    var service = window.asyncService;
    if (service === undefined) {
        throw new Error("Service is not loaded");
    }
    return service;
}
```
The present behaviour, on getting `container.asyncService` will throw the error once, and then afterwards return `undefined`. Even if the service resolves at some point, the result of `container.asyncService` will always be `undefined` after the initial call. 

This changes the behaviour so as to throw the error until the service resolves, and then behave as before. The use case is that I have services dependent on another service which is not ready until after `bottle.resolve()` has been called. I want to fail fast if anything tries to access that service before then.

It's a super-simple change in the code which just involves changing the order of when property names are deleted from the container vs when `$get` is called.