### PR TITLE
Throw when missing dependency (closes #43)

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -34,3 +34,10 @@ Bottle.prototype = {
  * Bottle static
  */
 Bottle.pop = pop;
+
+/**
+ * Global config
+ */
+Bottle.config = {
+    strict : false
+};

--- a/src/api.js
+++ b/src/api.js
@@ -38,6 +38,6 @@ Bottle.pop = pop;
 /**
  * Global config
  */
-Bottle.config = {
+var globalConfig = Bottle.config = {
     strict : false
 };

--- a/src/globals.js
+++ b/src/globals.js
@@ -79,12 +79,20 @@ var getMapped = function getMapped(collection, data) {
 /**
  * Iterator used to walk down a nested object.
  *
+ * If Bottle.config.strict is true, this method will throw an exception if it encounters an
+ * undefined path
+ *
  * @param Object obj
  * @param String prop
  * @return mixed
+ * @throws
  */
 var getNested = function getNested(obj, prop) {
-    return obj[prop];
+    var service = obj[prop];
+    if (service === undefined && globalConfig.strict) {
+        throw new Error('Bottle was unable to resolve a service.  `' + prop + '` is undefined.');
+    }
+    return service;
 };
 
 /**

--- a/test/spec/config.spec.js
+++ b/test/spec/config.spec.js
@@ -1,0 +1,18 @@
+/* globals Bottle */
+;(function() {
+    'use strict';
+
+    /**
+     * Bottle config test suite
+     */
+    describe('Bottle config', function() {
+        it('is a global property object', function() {
+            expect(Bottle.config).toEqual(jasmine.any(Object));
+        });
+        describe('config.strict', function() {
+            it('should be a boolean', function() {
+                expect(Bottle.config.strict).toEqual(jasmine.any(Boolean));
+            });
+        });
+    });
+}());

--- a/test/spec/service.spec.js
+++ b/test/spec/service.spec.js
@@ -71,5 +71,32 @@
             expect(b.container.Thing.sub).toBeDefined();
             expect(b.container.Thing.sub instanceof SubThing).toBe(true);
         });
+
+        describe('strict service resolution', function() {
+            afterEach(function() {
+                Bottle.config.strict = false;
+            });
+            it('will not care if a service is undefined when strict mode is off', function() {
+                var b = new Bottle();
+                var Thing = function(phantom) { this.phantom = phantom; };
+
+                Bottle.config.strict = false;
+                b.service('Thing', Thing, 'PhantomService');
+                expect(b.container.Thing).toBeDefined();
+                expect(b.container.Thing.phantom).toBeUndefined();
+            });
+            it('will throw an exception if a service is undefined in strict mode', function() {
+                var b = new Bottle();
+                var Thing = function(phantom) { this.phantom = phantom; };
+
+                Bottle.config.strict = true;
+                b.service('Thing', Thing, 'PhantomService');
+
+                var test = function() {
+                    return b.container.Thing;
+                };
+                expect(test).toThrowError(/PhantomService/);
+            });
+        });
     });
 }());


### PR DESCRIPTION
This PR adds a new global configuration object `Bottle.config`.

Setting `Bottle.config.strict = true` will cause bottle to throw an Error object when it encounters an undefined service.  Note:  This does **not** cause undefined services accessed directly as a container property to throw an error; these properties will still return `undefined`.