### PR TITLE
Allow for resetting providers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,10 @@ Param        | Type       | Details
 **name**     | *String*   | The name of the service.  Must be unique to each Bottle instance.
 **Provider** | *Function* | A constructor function that will be instantiated as a singleton.  Should expose a function called `$get` that will be used as a factory to instantiate the service.
 
+#### resetProviders()
+
+Used to reset all containers for the next reference to reinstantiate the provider.
+
 #### register(Obj)
 #### container.$register(Obj)
 

--- a/src/Bottle/provider.js
+++ b/src/Bottle/provider.js
@@ -22,6 +22,7 @@ var provider = function provider(fullname, Provider) {
     if (this.providerMap[fullname] && parts.length === 1 && !this.container[fullname + 'Provider']) {
         return console.error(fullname + ' provider already instantiated.');
     }
+    this.originalProviders[fullname] = Provider;
     this.providerMap[fullname] = true;
 
     name = parts.shift();
@@ -91,6 +92,25 @@ var createProvider = function createProvider(name, Provider) {
 
     Object.defineProperties(container, properties);
     return this;
+};
+
+var removeProviderMap = function resetProvider(name) {
+    this.providerMap[name] = false;
+    delete this.container[name];
+    delete this.container[name + 'Provider'];
+};
+
+var resetProviders = function resetProviders() {
+    var providers = this.originalProviders;
+    Object.keys(providers).forEach(function(provider) {
+        var parts = provider.split('.');
+        if (parts.length > 1) {
+            removeProviderMap.call(this, parts[0]);
+            parts.forEach(removeProviderMap.bind(getNestedBottle.call(this, parts[0])));
+        }
+        removeProviderMap.call(this, provider);
+        this.provider(provider, providers[provider]);
+    }.bind(this));
 };
 
 /**

--- a/src/Bottle/provider.js
+++ b/src/Bottle/provider.js
@@ -95,7 +95,7 @@ var createProvider = function createProvider(name, Provider) {
 };
 
 var removeProviderMap = function resetProvider(name) {
-    this.providerMap[name] = false;
+    delete this.providerMap[name];
     delete this.container[name];
     delete this.container[name + 'Provider'];
 };

--- a/src/api.js
+++ b/src/api.js
@@ -15,6 +15,7 @@ var Bottle = function Bottle(name) {
     this.middlewares = {};
     this.nested = {};
     this.providerMap = {};
+    this.originalProviders = {};
     this.deferred = [];
     this.container = {
         $register : register.bind(this),
@@ -35,6 +36,7 @@ Bottle.prototype = {
     list : list,
     middleware : middleware,
     provider : provider,
+    resetProviders : resetProviders,
     register : register,
     resolve : resolve,
     service : service,

--- a/test/spec/provider.spec.js
+++ b/test/spec/provider.spec.js
@@ -146,4 +146,26 @@
             expect(b.container.Zero).toBe(0);
         });
     });
+    describe('Bottle#resetProviders', function() {
+        it('allows for already instantiated providers to be reset back to their registry', function() {
+            var i = 0;
+            var b = new Bottle();
+            var ThingProvider = function() { i = ++i; this.$get = function() { return this; }; };
+            b.provider('Thing', ThingProvider);
+            expect(b.container.Thing instanceof ThingProvider).toBe(true);
+            b.resetProviders();
+            expect(b.container.Thing instanceof ThingProvider).toBe(true);
+            expect(i).toEqual(2);
+        });
+        it('allows for sub containers to re-initiate as well', function() {
+            var i = 0;
+            var b = new Bottle();
+            var ThingProvider = function() { i = ++i; this.$get = function() { return this; }; };
+            b.provider('Thing.Something', ThingProvider);
+            expect(b.container.Thing.Something instanceof ThingProvider).toBe(true);
+            b.resetProviders();
+            expect(b.container.Thing.Something instanceof ThingProvider).toBe(true);
+            expect(i).toEqual(2);
+        });
+    });
 }());

--- a/test/spec/provider.spec.js
+++ b/test/spec/provider.spec.js
@@ -153,6 +153,8 @@
             var ThingProvider = function() { i = ++i; this.$get = function() { return this; }; };
             b.provider('Thing', ThingProvider);
             expect(b.container.Thing instanceof ThingProvider).toBe(true);
+            // Intentionally calling twice to prove the construction is cached until reset
+            expect(b.container.Thing instanceof ThingProvider).toBe(true);
             b.resetProviders();
             expect(b.container.Thing instanceof ThingProvider).toBe(true);
             expect(i).toEqual(2);
@@ -162,6 +164,8 @@
             var b = new Bottle();
             var ThingProvider = function() { i = ++i; this.$get = function() { return this; }; };
             b.provider('Thing.Something', ThingProvider);
+            expect(b.container.Thing.Something instanceof ThingProvider).toBe(true);
+            // Intentionally calling twice to prove the construction is cached until reset
             expect(b.container.Thing.Something instanceof ThingProvider).toBe(true);
             b.resetProviders();
             expect(b.container.Thing.Something instanceof ThingProvider).toBe(true);


### PR DESCRIPTION
This allows for all providers on a bottle instance to be reset so that the next reference to a provider in the container will re-instantiate.

Edit:

The use case for this is if you wanted to use a file watcher like [`chokidar`](https://github.com/paulmillr/chokidar) to clear "cache" allowing for changes in source code to "reset" things that were instantiated and cached within bottle.