### PR TITLE
Update jasmine to latest version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-node_js: 0.10
+node_js:
+  - "4"
+  - "6"
 before_script:
   - npm install grunt-cli -g
   - npm install

--- a/grunt/config/grunt-contrib-jshint.json
+++ b/grunt/config/grunt-contrib-jshint.json
@@ -1,7 +1,8 @@
 {
     "jshint" : {
         "options" : {
-            "jshintrc" : ".jshintrc"
+            "jshintrc" : ".jshintrc",
+            "reporterOutput": ""
         },
         "source" : ["./gruntfile.js", "test/**/*.js", "dist/bottle.js"]
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.0",
-    "grunt-contrib-jasmine": "^0.7.0",
+    "grunt-contrib-jasmine": "^1.0.3",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.5.1",
     "grunt-wrap": "^0.3.0",


### PR DESCRIPTION
This fixes a bug related to newer versions of NPM and how dependencies are installed in the `node_modules/` directory.

Closes #74.

I tested this in:

* `v6.9.1` (npm `3.10.8`)
* `v4.5.0` (npm `2.15.9`)

Also included is an update to the `.travis.yml` to support current LTS versions of node.