### PR TITLE
Add another signature for service method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 .grunt
 _SpecRunner.html
+.idea

--- a/dist/bottle.d.ts
+++ b/dist/bottle.d.ts
@@ -72,6 +72,7 @@ declare class Bottle {
      * Register a service constructor. If Bottle.config.strict is set to true, this method will throw an error if an injected dependency is undefined.
      */
     service(name: string, Constructor: ((...any: any[]) => any), ...dependency: string[]): this;
+    service<T>(name: string, Constructor: new (...any: any[]) => T, ...dependency: string[]): this;
 
     /**
      * Add an arbitrary value to the container.


### PR DESCRIPTION
To be able to pass constructors into service method. Did not work in typescript 2.5.