### PR TITLE
Remove error message if a nested bottle with initialized services is extended

### DIFF
--- a/src/Bottle/provider.js
+++ b/src/Bottle/provider.js
@@ -105,8 +105,5 @@ var createProvider = function createProvider(name, Provider) {
 var createSubProvider = function createSubProvider(name, Provider, parts) {
     var bottle;
     bottle = getNestedBottle.call(this, name);
-    this.factory(name, function SubProviderFactory() {
-        return bottle.container;
-    });
     return bottle.provider(parts.join('.'), Provider);
 };

--- a/src/globals.js
+++ b/src/globals.js
@@ -39,7 +39,15 @@ var getNested = function getNested(obj, prop) {
  * @return Bottle
  */
 var getNestedBottle = function getNestedBottle(name) {
-    return this.nested[name] || (this.nested[name] = Bottle.pop());
+    var bottle;
+    if (!this.nested[name]) {
+        bottle = Bottle.pop();
+        this.nested[name] = bottle;
+        this.factory(name, function SubProviderFactory() {
+            return bottle.container;
+        });
+    }
+    return this.nested[name];
 };
 
 /**

--- a/test/spec/provider.spec.js
+++ b/test/spec/provider.spec.js
@@ -123,6 +123,18 @@
             expect(b.container.Util.ThingProvider).toBeDefined();
             expect(b.container.Util.Thing).toBeDefined();
         });
+        
+        it('does not log an error if a service is added to a nested bottle with initialized services', function() {
+            var b = new Bottle();
+            var Thing = function() {};
+            var ThingProvider = function() { this.$get = function() { return new Thing(); }; };
+            spyOn(console, 'error');
+            b.provider('Util.Thing', ThingProvider);
+            expect(b.container.Util.Thing).toBeDefined();
+            b.provider('Util.OtherThing', ThingProvider);
+            expect(b.container.Util.OtherThing).toBeDefined();
+            expect(console.error).not.toHaveBeenCalled();
+        });
 
         it('Allows falsey values returned by $get to remain defined when accessed multiple times', function() {
             var b = new Bottle();


### PR DESCRIPTION
The actual adding of the service worked already. This PR removes the error message due to the multiple definition of the factory for the nested bottle.