### PR TITLE
Fix #98

### DIFF
--- a/src/Bottle/reset-providers.js
+++ b/src/Bottle/reset-providers.js
@@ -20,7 +20,6 @@ var resetProviders = function resetProviders() {
     Object.keys(this.originalProviders).forEach(function resetPrvider(provider) {
         var parts = provider.split('.');
         if (parts.length > 1) {
-            removeProviderMap.call(this, parts[0]);
             parts.forEach(removeProviderMap, getNestedBottle.call(this, parts[0]));
         }
         removeProviderMap.call(this, provider);

--- a/test/spec/provider.spec.js
+++ b/test/spec/provider.spec.js
@@ -183,6 +183,16 @@
             expect(b.container.Thing.Something instanceof ThingProvider).toBe(true);
             expect(i).toEqual(2);
         });
+        it('will not break if a nested container has multiple children', function() {
+            var b = new Bottle();
+            b.service('Thing.A', function() { this.name = 'A'; });
+            b.service('Thing.B', function() { this.name = 'B'; });
+            expect(b.container.Thing.A.name).toBe('A');
+            expect(b.container.Thing.B.name).toBe('B');
+            b.resetProviders();
+            expect(b.container.Thing.A.name).toBe('A');
+            expect(b.container.Thing.B.name).toBe('B');
+        });
         it('allows for services with dependencies to be re-initiated with fresh instances', function() {
             var i = 0;
             var b = new Bottle();


### PR DESCRIPTION
When `resetProvider` is called, we do not want to kill the parent container for every child.