### PR TITLE
Add name param to resetProviders

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,9 +382,12 @@ Param        | Type       | Details
 **name**     | *String*   | The name of the service.  Must be unique to each Bottle instance.
 **Provider** | *Function* | A constructor function that will be instantiated as a singleton.  Should expose a function called `$get` that will be used as a factory to instantiate the service.
 
-#### resetProviders()
+#### resetProviders(names)
+Param                      | Type       | Details
+:--------------------------|:-----------|:--------
+**names**<br />*(optional)*| *Array*    | An array of strings which contains names of the providers to be reset.
 
-Used to reset all containers for the next reference to reinstantiate the provider.
+Used to reset providers for the next reference to re-instantiate the provider. If `names` param is passed, will reset only the named providers.
 
 #### register(Obj)
 #### container.$register(Obj)

--- a/src/Bottle/reset-providers.js
+++ b/src/Bottle/reset-providers.js
@@ -18,9 +18,10 @@ var removeProviderMap = function resetProvider(name) {
  */
 var resetProviders = function resetProviders(names) {
     var tempProviders = this.originalProviders;
+    var shouldFilter = Array.isArray(names);
 
     Object.keys(this.originalProviders).forEach(function resetProvider(originalProviderName) {
-        if (Array.isArray(names) && names.indexOf(originalProviderName) === -1) {
+        if (shouldFilter && names.indexOf(originalProviderName) === -1) {
             return;
         }
         var parts = originalProviderName.split(DELIMITER);

--- a/src/Bottle/reset-providers.js
+++ b/src/Bottle/reset-providers.js
@@ -11,18 +11,23 @@ var removeProviderMap = function resetProvider(name) {
 };
 
 /**
- * Resets all providers on a bottle instance.
+ * Resets providers on a bottle instance. If 'names' array is provided, only the named providers will be reset.
  *
+ * @param Array names
  * @return void
  */
-var resetProviders = function resetProviders() {
-    var providers = this.originalProviders;
-    Object.keys(this.originalProviders).forEach(function resetPrvider(provider) {
-        var parts = provider.split(DELIMITER);
+var resetProviders = function resetProviders(names) {
+    var tempProviders = this.originalProviders;
+
+    Object.keys(this.originalProviders).forEach(function resetProvider(originalProviderName) {
+        if (Array.isArray(names) && names.indexOf(originalProviderName) === -1) {
+            return;
+        }
+        var parts = originalProviderName.split(DELIMITER);
         if (parts.length > 1) {
             parts.forEach(removeProviderMap, getNestedBottle.call(this, parts[0]));
         }
-        removeProviderMap.call(this, provider);
-        this.provider(provider, providers[provider]);
+        removeProviderMap.call(this, originalProviderName);
+        this.provider(originalProviderName, tempProviders[originalProviderName]);
     }, this);
 };

--- a/test/spec/provider.spec.js
+++ b/test/spec/provider.spec.js
@@ -123,7 +123,7 @@
             expect(b.container.Util.ThingProvider).toBeDefined();
             expect(b.container.Util.Thing).toBeDefined();
         });
-        
+
         it('does not log an error if a service is added to a nested bottle with initialized services', function() {
             var b = new Bottle();
             var Thing = function() {};
@@ -170,6 +170,24 @@
             b.resetProviders();
             expect(b.container.Thing instanceof ThingProvider).toBe(true);
             expect(i).toEqual(2);
+        });
+        it('allows for selectively resetting providers by name', function() {
+          var i = 0;
+          var j = 0;
+          var b = new Bottle();
+          var FirstProvider = function() { i = ++i; this.$get = function() { return this; }; };
+          var SecondProvider = function() { j = ++j; this.$get = function() { return this; }; };
+          b.provider('First', FirstProvider);
+          b.provider('Second', SecondProvider);
+          expect(b.container.First instanceof FirstProvider).toBe(true);
+          expect(b.container.Second instanceof SecondProvider).toBe(true);
+          expect(i).toEqual(1);
+          expect(j).toEqual(1);
+          b.resetProviders(['First']);
+          expect(b.container.First instanceof FirstProvider).toBe(true);
+          expect(b.container.Second instanceof SecondProvider).toBe(true);
+          expect(i).toEqual(2);
+          expect(j).toEqual(1);
         });
         it('allows for sub containers to re-initiate as well', function() {
             var i = 0;


### PR DESCRIPTION
Adds 'name' parameter for resetProviders. Allows for selectively resetting some providers while keeping the original instances of others.

Thank you for your work on this library!