### PR TITLE
Add ES module build

### DIFF
--- a/grunt/config/grunt-contrib-concat.json
+++ b/grunt/config/grunt-contrib-concat.json
@@ -1,25 +1,39 @@
 {
-    "concat" : {
-        "dist" : {
-            "options" : {
-                "stripBanners" : false,
-                "separator" : "\n",
-                "banner" : "/**\n * BottleJS v<%= pkg.version %> - <%= grunt.template.today('yyyy-mm-dd') %>\n * <%= pkg.description %>\n *\n * Copyright (c) <%= grunt.template.today('yyyy') %> Stephen Young\n * Licensed <%= pkg.license %>\n */\n"
+    "concat": {
+        "dist": {
+            "options": {
+                "stripBanners": false,
+                "separator": "\n",
+                "banner": "/**\n * BottleJS v<%= pkg.version %> - <%= grunt.template.today('yyyy-mm-dd') %>\n * <%= pkg.description %>\n *\n * Copyright (c) <%= grunt.template.today('yyyy') %> Stephen Young\n * Licensed <%= pkg.license %>\n */\n"
             },
-            "src" : [
-                "src/globals.js",
-                "src/Bottle/middleware.js",
-                "src/Bottle/provider.js",
-                "src/Bottle/factory.js",
-                "src/Bottle/service.js",
-                "src/Bottle/service-factory.js",
-                "src/Bottle/value.js",
-                "src/Bottle/constant.js",
-                "src/Bottle/**.js",
-                "src/api.js",
-                "src/export.js"
-            ],
-            "dest" : "dist/bottle.js"
+            "files": {
+                "dist/bottle.js": [
+                    "src/globals.js",
+                    "src/Bottle/middleware.js",
+                    "src/Bottle/provider.js",
+                    "src/Bottle/factory.js",
+                    "src/Bottle/service.js",
+                    "src/Bottle/service-factory.js",
+                    "src/Bottle/value.js",
+                    "src/Bottle/constant.js",
+                    "src/Bottle/**.js",
+                    "src/api.js",
+                    "src/export.js"
+                ],
+                "dist/bottle-es.js": [
+                    "src/globals.js",
+                    "src/Bottle/middleware.js",
+                    "src/Bottle/provider.js",
+                    "src/Bottle/factory.js",
+                    "src/Bottle/service.js",
+                    "src/Bottle/service-factory.js",
+                    "src/Bottle/value.js",
+                    "src/Bottle/constant.js",
+                    "src/Bottle/**.js",
+                    "src/api.js",
+                    "src/export-es.js"
+                ]
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.7.2",
   "description": "A powerful dependency injection micro container",
   "main": "dist/bottle.js",
+  "module": "dist/bottle-es.js",
   "typings": "dist/bottle.d.ts",
   "scripts": {
     "test": "grunt test"

--- a/src/export-es.js
+++ b/src/export-es.js
@@ -1,0 +1,1 @@
+export default Bottle


### PR DESCRIPTION
Fixes #129 

Adds an ES module build along side existing one.

Code wise there's no change. I tested in a webpack project and is working fine.

Anyway is a breaking change because webpack users that import bottle with require will break:

```js
import Bottle from 'bottlejs'; // works fine as before

const Bottle = require('bottlejs'); // does not work

// would need to change to 

const Bottle = require('bottlejs').default;
```

This is far from ideal.

Solutions:
1) Avoid default export and use an named export. Would be consumed as below being consistent for both ES and CJS consumers
```js
// ES import
import { Bottle } from 'bottlejs'; 
// CJS require
const { Bottle } = require('bottlejs');
```

2) Do not use module entry in package. The users by default would still use the UMD build (no Breaking Change) and to use es module version would need to be explicit:

```js
// ES import
import Bottle from 'bottlejs/dist/bottle-es'; 
```

Personally i'm in favor of 1 since is a better solution long term but 2 is also doable.

Some context:

https://github.com/markedjs/marked/pull/1571#issuecomment-562891963
https://github.com/webpack/webpack/issues/4742#issuecomment-462789849